### PR TITLE
fix crash while reprocessing a night with bad data

### DIFF
--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -83,7 +83,7 @@ def selectFiles(dir_path, ff_detected):
 
 
         # Add FF file which contain detections to the list
-        if file_name in ff_detected:
+        if (ff_detected is not None) and (file_name in ff_detected):
             selected_list.append(file_name)
 
 
@@ -244,3 +244,4 @@ if __name__ == "__main__":
     archive_name = archiveDetections(captured_path, archived_path, ff_detected, config)
 
     print(archive_name)
+

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -163,7 +163,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
 
         # Run calibration check and auto astrometry refinement
-        if platepar is not None:
+        if (platepar is not None) and (calstars_name is not None):
 
             # Read in the CALSTARS file
             calstars_list = CALSTARS.readCALSTARS(night_data_dir, calstars_name)


### PR DESCRIPTION
This patch avoids python crash after reprocessing a night containing bad data.
Problem identified while reprocessing 'BR0001_20191003_215648_615365'